### PR TITLE
/adds builtinvalues to vyper.vim

### DIFF
--- a/syntax/vyper.vim
+++ b/syntax/vyper.vim
@@ -27,8 +27,9 @@ syn keyword vyperTypes int8 int16 int24 int32 int40 int48 int56 int64 int72 int8
 syn keyword vyperTypes uint8 uint16 uint24 uint32 uint40 uint48 uint56 uint64 uint72 uint80 uint88 uint96 uint104 uint112 uint120 uint128 uint136 uint144 uint152 uint160 uint168 uint176 uint184 uint192 uint200 uint208 uint216 uint224 uint232 uint240 uint248 uint256
 syn keyword vyperTypes Bytes String HashMap
 syn keyword vyperBuiltin as_unitless_number as_wei_value bitwise_and bitwise_not bitwise_or bitwise_xor blockhash ceil concat
-syn keyword vyperBuiltin convert create_with_code_of ecadd ecmul ecrecover extract32 floor keccak256 len max method_id min raw_call
-syn keyword vyperBuiltin sha3 shift slice uint256_addmod uint256_mulmod
+syn keyword vyperBuiltin convert create_with_code_of ecadd ecmul ecrecover extract32 floor keccak256 len max method_id min raw_call empty
+syn keyword vyperBuiltin sha3 shift slice uint256_addmod uint256_mulmod sha256 pow_mod256
+
 syn keyword vyperBuiltin indexed public constant
 syn keyword vyperTodo TODO FIXME NOTE contained
 


### PR DESCRIPTION
Adds missing values `sha256`, `pow_mod256`, and `empty` for [built in functions](ttps://github.com/vyperlang/vyper/blob/master/docs/built-in-functions.rst) to vyper

Source `sha256`:

```
.. py:function:: pow_mod256(a: uint256, b: uint256) -> uint256

    Return the result of ``a ** b % (2 ** 256)``.

    This method is used to perform exponentiation without overflow checks.

    .. code-block:: python

        @external
        @view
        def foo(a: uint256, b: uint256) -> uint256:
            return pow_mod256(a, b)

    .. code-block:: python

        >>> ExampleContract.foo(2, 3)
        8
        >>> ExampleContract.foo(100, 100)
        59041770658110225754900818312084884949620587934026984283048776718299468660736
```

Source `pow_mod256`: 

```
.. py:function:: sha256(_value) -> bytes32

    Return a ``sha256`` (SHA2 256-bit output) hash of the given value.

    * ``_value``: Value to hash. Can be a literal string, ``Bytes``, or ``bytes32``.

    .. code-block:: python

        @external
        @view
        def foo(_value: Bytes[100]) -> bytes32
            return sha256(_value)

    .. code-block:: python

        >>> ExampleContract.foo(b"potato")
        0xe91c254ad58860a02c788dfb5c1a65d6a8846ab1dc649631c7db16fef4af2dec
```

Source `empty`: 

```
.. py:function:: empty(typename) -> Any

    Return a value which is the default (zero-ed) value of its type. Useful for initializing new memory variables.

    * ``typename``: Name of the type

    .. code-block:: python

        @external
        @view
        def foo():
            x: uint256[2][5] = empty(uint256[2][5])
```
