### PR TITLE
Add support for native hex string literals

### DIFF
--- a/syntax/vyper.vim
+++ b/syntax/vyper.vim
@@ -70,11 +70,12 @@ syn match vyperNumber "\<\d\>" display
 syn match vyperNumber "\<[1-9]\d\+\>" display
 syn match vyperNumberError "\<0\d\+\>" display
 syn match vyperHex "\<0x\x\{2,64}\>" display
-syn match vyperHexLiteral /\<x"\x\+"/ display
-syn match vyperByteString /\<b"[^"]*"\>/ display
+syn match vyperHexLiteral "\<x\"[0-9A-Fa-f]\+\"\>" display
+syn match vyperByteString "\<b\"[^\"]*\"\>" display
 syn match vyperAddress "\<0x\x\{40}\>" display
 syn match vyperHexLiteralError "\<0x\x\{65,}\>" display
 syn match vyperHexLiteralError "\<0x\x*\X\+.\+\>" display
+syn match vyperHexLiteralError "\<x\"[0-9A-Fa-f]*[^0-9A-Fa-f\"]\+.*\"\>" display
 syn match vyperDecimal "\<\d*\.\d\+\>" display
 
 "String literals

--- a/syntax/vyper.vim
+++ b/syntax/vyper.vim
@@ -70,7 +70,8 @@ syn match vyperNumber "\<\d\>" display
 syn match vyperNumber "\<[1-9]\d\+\>" display
 syn match vyperNumberError "\<0\d\+\>" display
 syn match vyperHex "\<0x\x\{2,64}\>" display
-syn match vyperHexString /\<x"\x\+"/ display
+syn match vyperHexLiteral /\<x"\x\+"/ display
+syn match vyperByteString /\<b"[^"]*"\>/ display
 syn match vyperAddress "\<0x\x\{40}\>" display
 syn match vyperHexLiteralError "\<0x\x\{65,}\>" display
 syn match vyperHexLiteralError "\<0x\x*\X\+.\+\>" display
@@ -115,7 +116,8 @@ hi link vyperTypes Type
 hi link vyperNumber Number
 hi link vyperAddress Number
 hi link vyperHex Number
-hi link vyperHexString vyperHex
+hi link vyperHexLiteral vyperHex
+hi link vyperByteString String
 hi link vyperHexLiteralError Error
 hi link vyperDecimal Float
 hi link vyperFunction Function

--- a/syntax/vyper.vim
+++ b/syntax/vyper.vim
@@ -70,12 +70,12 @@ syn match vyperNumber "\<\d\>" display
 syn match vyperNumber "\<[1-9]\d\+\>" display
 syn match vyperNumberError "\<0\d\+\>" display
 syn match vyperHex "\<0x\x\{2,64}\>" display
-syn match vyperHexLiteral "\<x\"[0-9A-Fa-f]\+\"\>" display
+syn match vyperHexLiteral "\<x\"\x\+\"\>" display
 syn match vyperByteString "\<b\"[^\"]*\"\>" display
 syn match vyperAddress "\<0x\x\{40}\>" display
 syn match vyperHexLiteralError "\<0x\x\{65,}\>" display
 syn match vyperHexLiteralError "\<0x\x*\X\+.\+\>" display
-syn match vyperHexLiteralError "\<x\"[0-9A-Fa-f]*[^0-9A-Fa-f\"]\+.*\"\>" display
+syn match vyperHexLiteralError "\<x\"\x*[^0-9A-Fa-f\"]\+.*\"\>" display
 syn match vyperDecimal "\<\d*\.\d\+\>" display
 
 "String literals
@@ -117,7 +117,7 @@ hi link vyperTypes Type
 hi link vyperNumber Number
 hi link vyperAddress Number
 hi link vyperHex Number
-hi link vyperHexLiteral vyperHex
+hi link vyperHexLiteral String
 hi link vyperByteString String
 hi link vyperHexLiteralError Error
 hi link vyperDecimal Float

--- a/syntax/vyper.vim
+++ b/syntax/vyper.vim
@@ -70,7 +70,7 @@ syn match vyperNumber "\<\d\>" display
 syn match vyperNumber "\<[1-9]\d\+\>" display
 syn match vyperNumberError "\<0\d\+\>" display
 syn match vyperHex "\<0x\x\{2,64}\>" display
-syn match vyperHexString /\<x"\x\{2,64}"/ display
+syn match vyperHexString /\<x"\x\+"/ display
 syn match vyperAddress "\<0x\x\{40}\>" display
 syn match vyperHexLiteralError "\<0x\x\{65,}\>" display
 syn match vyperHexLiteralError "\<0x\x*\X\+.\+\>" display

--- a/syntax/vyper.vim
+++ b/syntax/vyper.vim
@@ -70,6 +70,7 @@ syn match vyperNumber "\<\d\>" display
 syn match vyperNumber "\<[1-9]\d\+\>" display
 syn match vyperNumberError "\<0\d\+\>" display
 syn match vyperHex "\<0x\x\{2,64}\>" display
+syn match vyperHexString /\<x"\x\{2,64}"/ display
 syn match vyperAddress "\<0x\x\{40}\>" display
 syn match vyperHexLiteralError "\<0x\x\{65,}\>" display
 syn match vyperHexLiteralError "\<0x\x*\X\+.\+\>" display
@@ -114,6 +115,7 @@ hi link vyperTypes Type
 hi link vyperNumber Number
 hi link vyperAddress Number
 hi link vyperHex Number
+hi link vyperHexString vyperHex
 hi link vyperHexLiteralError Error
 hi link vyperDecimal Float
 hi link vyperFunction Function


### PR DESCRIPTION
Add support syntax highlighting for native hex string literals, e.g. `x"01"`. Vyper introduced this syntax in  https://github.com/vyperlang/vyper/pull/4271.